### PR TITLE
Fix graph zoom when service description has '#' chars

### DIFF
--- a/share/pnp/application/views/graph_content.php
+++ b/share/pnp/application/views/graph_content.php
@@ -83,7 +83,15 @@ foreach($this->data->STRUCT as $key=>$value){
 		.Kohana::lang('common.service',$value['MACRO']['DISP_SERVICEDESC']) . " " 
 		.Kohana::lang('common.datasource',$value['ds_name']) . " " 
 		."\">\n";
-	echo "<div start=".$value['TIMERANGE']['start']." end=".$value['TIMERANGE']['end']." style=\"width:".$value['GRAPH_WIDTH']."px; height:".$value['GRAPH_HEIGHT']."px; position:absolute; top:33px\" class=\"graph\" id=\"".$this->url."\" ></div>";
+	
+	# urlencode the graph id, to prevent # chars in service names being 
+	# treated like a url fragment when zooming
+ 	$gid = array();
+        parse_str(ltrim($this->url, '?'), $gid);
+        $gid = htmlentities("?host=".urlencode($gid["host"])."&srv=".urlencode($gid["srv"]));
+
+	echo "<div start=".$value['TIMERANGE']['start']." end=".$value['TIMERANGE']['end']." style=\"width:".$value['GRAPH_WIDTH']."px; height:".$value['GRAPH_HEIGHT']."px; position:absolute; top:33px\" class=\"graph\" id=\"".$gid."\" ></div>";
+        
         $path = pnp::addToUri( array(
                                 'host'   => $value['MACRO']['HOSTNAME'],
                                 'srv'    => $value['MACRO']['SERVICEDESC'],


### PR DESCRIPTION
Graphs for services with '#' character in service description are parsed as URL fragments when zooming.

For instance, consider for a Nagios check, with HOST="localhost"; SRV="Team Adapter #1":

  * `$this->url` contains a decoded form of the host/service querystring pair:
    - `"?host=localhost&srv=Team_Adapter_#1"`
  * originally, the graph container's `id` attribute was set to the contents of `$this->id`:
    - `<div ... id="?host=localhost&srv=Team_Adapter_#1">`
  * elsewhere, the zoom feature's imgAreaSelect onrelease event handler sets window.location to the div's id 
    - `window.location = "?host=localhost&srv=Team_Adapter_#1&start=1401010101&end=1402020202"`
  * the '#' char is treated like a URL fragment
  * when PNP loads the zoom page, it reads the `srv` query parameter incompletely, and excludes the trailing querystring params
    - `$srv = "Team_Adapter_"`
  * PNP looks for the XML file in the wrong place (e.g. `var/perfdata/localhost/Team_Adapter_.xml`), cannot find it and throws an exception

After the patch:

  * `$this->url` is passed through `parse_str` to form an array
  * graph container `id` attribute recomposed from `urlencode(...)`-wrapped array values
  * `id` parameter now reads `?host=localhost&srv=Team_Adapter_%231`
  * when PNP loads the zoom page, it now reads the `srv` query parameter completely and locates the right XML file